### PR TITLE
feat: add flag to run the server without TLS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,12 +9,14 @@ import (
 
 func main() {
 	var port int
+	var enableTLS bool
 	flag.IntVar(&port, "port", 9003, "Listening Port")
+	flag.BoolVar(&enableTLS, "enableTLS", true, "Run server with TLS (default true)")
 	flag.Parse()
 	logger := logging.NewLogger().Named("metric-sever")
 	ctx := context.Background()
 	defer ctx.Done()
 
-	metricsServer := server.NewO11yServer(logger, port)
+	metricsServer := server.NewO11yServer(logger, port, enableTLS)
 	metricsServer.Run(ctx)
 }


### PR DESCRIPTION
This PR adds a flag to disable running the server with TLS. This is necessary when deploying in istio enabled environments where istio proxy sidecar does TLS termination.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
