### PR TITLE
Set ChartData key to pod when prometheus metrics contain multiple keys

### DIFF
--- a/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/ChartWrapper.tsx
+++ b/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/ChartWrapper.tsx
@@ -130,7 +130,7 @@ export const ChartWrapper = ({
             }
             const metricObj: ChartDataProps = {
               ...obj,
-              name: obj?.metric && Object.values(obj?.metric).join(":"),
+              name: obj?.metric && typeof obj?.metric?.pod === 'string' ? obj?.metric?.pod: Object.values(obj?.metric).join(":"),
               data: [],
             };
             obj?.values?.map((kp: [any, any], i: number) => {

--- a/extensions/resource-metrics/resource-metrics-extention/ui/src/index.tsx
+++ b/extensions/resource-metrics/resource-metrics-extention/ui/src/index.tsx
@@ -83,11 +83,4 @@ export const component = Extension;
     "Metrics",
     { icon: "fa fa-chart-area" }
   );
-  window?.extensionsAPI?.registerResourceExtension(
-    component,
-    "",
-    "Pod",
-    "Metrics",
-    { icon: "fa fa-chart-area" }
-  );
 })(window);


### PR DESCRIPTION
Line chart does not render correctly when Prometheus response metrics contain multiple key/value pairs.  As there are multiple keys, it is constructed very long name in the [chartdata](https://github.com/argoproj-labs/argocd-extension-metrics/blob/main/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/ChartWrapper.tsx#L133), causing render issue (possibly due to upstream issue in line chart). As a result, an if condition was added to filter pod names to only have one unique name.
e.g
```
"metric": {
            "__name__": "namespace_argocd_pod_memory_usage_bytes",
            "assetId": "xx",
            "namespace": "sandbox-rollout-xx-x",
            "pod": "numalogic-rollout-x",
            "receive": "true",
            "tenant_id": "default"
        }
```