### PR TITLE
fix(ui): avoid class name that conflicts with Argo CD UI

### DIFF
--- a/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/Chart.scss
+++ b/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/Chart.scss
@@ -183,7 +183,7 @@ div:hover > div > .metrics-charts__legend_wrapper {
   margin: 2px 0;
 }
 
-.input-container {
+.chart-input-container {
   display: flex;
   font-size: 16px;
   margin-left: 50px;

--- a/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/Chart.tsx
+++ b/extensions/resource-metrics/resource-metrics-extention/ui/src/Metrics/Chart/Chart.tsx
@@ -515,7 +515,7 @@ export const TimeSeriesChart = ({
 
                 </LineChart>
               </ResponsiveContainer>
-              {(chartData?.thresholds.length > 0) && (<div className="input-container">
+              {(chartData?.thresholds.length > 0) && (<div className="chart-input-container">
                 <label className="label-container">
                   <input
                     type="checkbox"


### PR DESCRIPTION
The current class name clashes with an Argo CD UI class name and causes weirdness.

![image](https://github.com/argoproj-labs/argocd-extension-metrics/assets/350466/ea15e4e4-84cf-41b4-b61f-b8b909cd7b99)
