### PR TITLE
feat/prometheus-provider-additional-headers

### DIFF
--- a/docs/configuration/prometheus-provider.md
+++ b/docs/configuration/prometheus-provider.md
@@ -1,0 +1,32 @@
+# Prometheus Provider
+
+## Overview
+
+The `provider` section under the `prometheus` configuration specifies how the extension connects to a Prometheus server. It includes settings such as server address, TLS configuration, and custom headers.
+
+## Example
+
+```json
+{
+  "name": "default",
+  "default": true,
+  "address": "https://localhost:9090",
+  "TLSConfig": {
+    "insecure_skip_verify": true
+  },
+  "headers": {
+    "Authorization": ["Bearer TOKEN"],
+    "Accept": ["application/json"]
+  }
+}
+```
+
+## Fields
+
+| Field                       | Description                                      | Required |
+|-----------------------------|--------------------------------------------------|----------|
+| `name`                      | Identifier for the provider.                     | Yes      |
+| `default`                   | Set to `true` if this is the default provider.   | Yes      |
+| `address`                   | URL of the Prometheus server.                    | Yes      |
+| `TLSConfig.insecure_skip_verify` | Skip TLS verification.                      | No       |
+| `headers`                   | Prometheus additional headers.                   | No       |

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/prometheus/common/config"
 )
@@ -85,6 +86,7 @@ type provider struct {
 	Address   string           `json:"address"`
 	Default   bool             `json:"default"`
 	TLSConfig config.TLSConfig `json:"TLSConfig"`
+	Headers   http.Header      `json:"headers"`
 }
 
 type MetricsConfigProvider struct {

--- a/internal/server/prometheus.go
+++ b/internal/server/prometheus.go
@@ -72,6 +72,9 @@ func NewPrometheusProvider(prometheusConfig *MetricsConfigProvider, logger *zap.
 	return &PrometheusProvider{config: prometheusConfig, logger: logger}
 }
 
+// RoundTrip adds custom headers to each HTTP request before forwarding it.
+// Acts like middleware for injecting headers into Prometheus API calls.
+// Implements the http.RoundTripper interface.
 func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	for key, values := range h.headers {
 		for _, value := range values {

--- a/internal/server/prometheus.go
+++ b/internal/server/prometheus.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -39,6 +40,11 @@ type PrometheusProvider struct {
 	config   *MetricsConfigProvider
 }
 
+type headerRoundTripper struct {
+	headers http.Header
+	rt      http.RoundTripper
+}
+
 func (pp *PrometheusProvider) getType() string {
 	return PROMETHEUS_TYPE
 }
@@ -66,9 +72,33 @@ func NewPrometheusProvider(prometheusConfig *MetricsConfigProvider, logger *zap.
 	return &PrometheusProvider{config: prometheusConfig, logger: logger}
 }
 
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, values := range h.headers {
+		for _, value := range values {
+			if len(value) > 0 {
+				req.Header.Add(key, value)
+			}
+		}
+	}
+
+	return h.rt.RoundTrip(req)
+}
+
 func (pp *PrometheusProvider) init() error {
+	additionalHeaders := pp.config.Provider.Headers
+	var rt http.RoundTripper = http.DefaultTransport
+	if pp.config.Provider.TLSConfig.InsecureSkipVerify {
+		rt = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
 	client, err := api.NewClient(api.Config{
 		Address: pp.config.Provider.Address,
+		RoundTripper: &headerRoundTripper{
+			headers: additionalHeaders,
+			rt:      rt,
+		},
 	})
 	if err != nil {
 		pp.logger.Errorf("Error creating client: %v\n", err)


### PR DESCRIPTION
🐛 (internal/server/config.go): add support for HTTP headers in Prometheus provider configuration
✨ (internal/server/prometheus.go): add support for additional HTTP headers in Prometheus provider