### PR TITLE
Add support for mimir tenant header & TLS (insecure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 .idea/
+.tool-versions
 vendor/
 dist/
 bin/
+test/
 extensions/resource-metrics/resource-metrics-extention/ui/dist
 extensions/resource-metrics/resource-metrics-extention/ui/package-lock.json
 extensions/resource-metrics/resource-metrics-extention/ui/extension.tar
+cmd/app/config.json
+cmd/__debug_bin*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Package",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/main.go"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from golang base image
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 
 # Enable go modules
 ENV GO111MODULE=on
@@ -34,7 +34,6 @@ RUN CGO_ENABLED=0 go build -o ./bin/metrics-server ./cmd/main.go
 
 # Start a new stage from scratch
 FROM scratch
-
 COPY --from=builder /app/bin/metrics-server /
 
 ENTRYPOINT [ "/metrics-server" ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+
 	"github.com/argoproj-labs/argocd-metric-ext-server/internal/logging"
 	"github.com/argoproj-labs/argocd-metric-ext-server/internal/server"
 )

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -83,8 +83,10 @@ func (a Application) getDashBoard(groupKind string) *Dashboard {
 type provider struct {
 	Name      string           `json:"name"`
 	Address   string           `json:"address"`
+	Insecure  bool             `json:"insecure"`
 	Default   bool             `json:"default"`
 	TLSConfig config.TLSConfig `json:"TLSConfig"`
+	Tenant    string           `json:"tenant"`
 }
 
 type MetricsConfigProvider struct {

--- a/internal/server/mimir.go
+++ b/internal/server/mimir.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// mimirRoundTripper is a custom http.RoundTripper that adds the X-Scope-OrgID header to requests.
+type mimirRoundTripper struct {
+	logger       *zap.SugaredLogger
+	tenant       string
+	roundTripper http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface and adds the X-Scope-OrgID header to the request.
+func (m *mimirRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	m.logger.Infof("Adding X-Scope-OrgID %s header to request: %s", m.tenant, request.URL.String())
+	clonedRequest := new(http.Request)
+	*clonedRequest = *request
+	clonedRequest.Header = make(http.Header)
+	for k, s := range request.Header {
+		clonedRequest.Header[k] = s
+	}
+	clonedRequest.Header.Set("X-Scope-OrgID", m.tenant)
+	request = clonedRequest
+	return m.roundTripper.RoundTrip(request)
+}


### PR DESCRIPTION
Currently there's no way to pass along an `X-Scope-OrgID` header to mimir prometheus compatible endpoint to query the corresponding metrics.
At the same time, due to how the image is built `from scratch` it lacks any CA certificates, which means that connections to HTTPS enabled servers is never trusted.

- This PR adds a configuration option for a single `tenant` to be passed into mirmir.
- This PR adds a configuration option `insecure` to make HTTPS request skipping cert verification