### PR TITLE
Feat: Add well-known CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ RUN CGO_ENABLED=0 go build -o ./bin/metrics-server ./cmd/main.go
 FROM scratch
 
 COPY --from=builder /app/bin/metrics-server /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT [ "/metrics-server" ]


### PR DESCRIPTION
Copies the CA certificates from the builder stage (Alpine) into the final image.

It avoids the need of skipping TLS checks (like it could be done with the evolution in https://github.com/argoproj-labs/argocd-extension-metrics/pull/89)